### PR TITLE
correct deepvariant flag invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Command-line tool for [left-aligning and normalizing](https://genome.sph.umich.edu/wiki/Variant_Normalization#Algorithm_for_Normalization) gVCF variants**
 
-**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `../run_deevariant.py --make_examples_extra_args normalize_reads=true`.
+**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `run_deevariant.py --make_examples_extra_args normalize_reads=true`.
 
 Same algorithm as `vt normalize` and `bcftools norm -f`, but tolerates gVCF's idioms: (i) ignores any symbolic alleles in variant records (`<NON_REF>`, `<*>`, `*`), and (ii) passes through reference bands unchanged.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Command-line tool for [left-aligning and normalizing](https://genome.sph.umich.edu/wiki/Variant_Normalization#Algorithm_for_Normalization) gVCF variants**
 
-**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option `--normalize-reads` to ensure indel left-alignment, replacing this utility**
+**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `../run_deevariant.py --make_examples_extra_args normalize_reads=true`.
 
 Same algorithm as `vt normalize` and `bcftools norm -f`, but tolerates gVCF's idioms: (i) ignores any symbolic alleles in variant records (`<NON_REF>`, `<*>`, `*`), and (ii) passes through reference bands unchanged.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Command-line tool for [left-aligning and normalizing](https://genome.sph.umich.edu/wiki/Variant_Normalization#Algorithm_for_Normalization) gVCF variants**
 
-**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `run_deepvariant.py --make_examples_extra_args normalize_reads=true`.
+**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `make_examples --normalize-reads` or `run_deepvariant --make_examples_extra_args normalize_reads=true`.
 
 Same algorithm as `vt normalize` and `bcftools norm -f`, but tolerates gVCF's idioms: (i) ignores any symbolic alleles in variant records (`<NON_REF>`, `<*>`, `*`), and (ii) passes through reference bands unchanged.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Command-line tool for [left-aligning and normalizing](https://genome.sph.umich.edu/wiki/Variant_Normalization#Algorithm_for_Normalization) gVCF variants**
 
-**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `run_deevariant.py --make_examples_extra_args normalize_reads=true`.
+**NOTICE: [DeepVariant v1.3.0+](https://github.com/google/deepvariant/releases/tag/v1.3.0) has a built-in option to ensure indel left-alignment, replacing this utility**. Enable it with `run_deepvariant.py --make_examples_extra_args normalize_reads=true`.
 
 Same algorithm as `vt normalize` and `bcftools norm -f`, but tolerates gVCF's idioms: (i) ignores any symbolic alleles in variant records (`<NON_REF>`, `<*>`, `*`), and (ii) passes through reference bands unchanged.
 


### PR DESCRIPTION
It seems to be  a `make_examples` arg, so has to go in `--make_examples_extra_args`